### PR TITLE
feat: Modify scroll event and sold out product link

### DIFF
--- a/js/body.js
+++ b/js/body.js
@@ -731,6 +731,10 @@ function userAccountForm(totalBalance) {
 
 // 상품 상세페이지
 function detailForm(product) {
+  startTop()
+  function startTop() {
+    window.scrollTo(0, 0)
+  }
 
   if (product.thumbnail === null || product.thumbnail === undefined) {
     product.thumbnail = './images/preparingProduct.jpg'

--- a/js/detail.js
+++ b/js/detail.js
@@ -1,5 +1,6 @@
 export function buyProduct(product) {
   const buyBtn = document.querySelector('.buy-btn')
+  const selling = product.isSoldOut === true ? false : true
   buyBtn.addEventListener('click', () => {
     let newProduct = {
       'ID': product.id,
@@ -11,7 +12,8 @@ export function buyProduct(product) {
     }
     localStorage.setItem('cart', JSON.stringify([newProduct]))
     const accessToken = localStorage.accessToken
-    if (accessToken) location.hash = '#payment'
+    if (accessToken && selling) location.hash = '#payment'
+    else if (accessToken) popMessage()
     else location.hash = '#login'
   })
 }
@@ -51,11 +53,19 @@ async function cart(product) {
 
 export function shoppingBasket(product) {
   const cartBtn = document.querySelector('.cart-btn')
+  const tabMenu = document.querySelector('.tab-menu')
   const selling = product.isSoldOut === true ? false : true
   cartBtn.addEventListener('click', () => {
     cart(product)
     if (selling) showModal(product)
     else popMessage()
+  })
+  tabMenu.addEventListener('click', ({ target }) => {
+    const topBanner = document.querySelector('.top-banner')
+    const el = target['name']
+    const nameEl = document.querySelector(`.${el}`)
+    const scrollH = nameEl.getBoundingClientRect().top - topBanner.offsetHeight
+    scrollTo({ left: 0, top: window.pageYOffset + scrollH, behavior: 'smooth' })
   })
 }
 


### PR DESCRIPTION
- detail 페이지 렌더 시 스크롤 맨 위로 이동
- 사라졌던 스크롤 이벤트 관련 코드 추가
- 품절 상품 바로 구매하기(.buy-btn) 클릭하면 품절 팝업 메세지 띄우기 추가